### PR TITLE
Place a useful cmake function 'link_to_faiss_lib' into a separate fil…

### DIFF
--- a/cmake/link_to_faiss_lib.cmake
+++ b/cmake/link_to_faiss_lib.cmake
@@ -1,0 +1,55 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+function(link_to_faiss_lib target)
+  if(NOT FAISS_OPT_LEVEL STREQUAL "avx2" AND NOT FAISS_OPT_LEVEL STREQUAL "avx512" AND NOT FAISS_OPT_LEVEL STREQUAL "sve")
+    target_link_libraries(${target} PRIVATE faiss)
+  endif()
+
+  if(FAISS_OPT_LEVEL STREQUAL "avx2")
+    if(NOT WIN32)
+      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma>)
+    else()
+      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX2>)
+    endif()
+    target_link_libraries(${target} PRIVATE faiss_avx2)
+  endif()
+
+  if(FAISS_OPT_LEVEL STREQUAL "avx512")
+    if(NOT WIN32)
+      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mavx512f -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw>)
+    else()
+      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX512>)
+    endif()
+    target_link_libraries(${target} PRIVATE faiss_avx512)
+  endif()
+
+  if(FAISS_OPT_LEVEL STREQUAL "sve")
+    if(NOT WIN32)
+      if("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )-march=native")
+        # Do nothing, expect SVE to be enabled by -march=native
+      elseif("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )(-march=armv[0-9]+(\\.[1-9]+)?-[^+ ](\\+[^+$ ]+)*)")
+        # Add +sve
+        target_compile_options(${target}  PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:${CMAKE_MATCH_2}+sve>)
+      elseif(NOT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )-march=armv")
+        # No valid -march, so specify -march=armv8-a+sve as the default
+        target_compile_options(${target} PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-march=armv8-a+sve>)
+      endif()
+      if("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )-march=native")
+        # Do nothing, expect SVE to be enabled by -march=native
+      elseif("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )(-march=armv[0-9]+(\\.[1-9]+)?-[^+ ](\\+[^+$ ]+)*)")
+        # Add +sve
+        target_compile_options(${target}  PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RELEASE>>:${CMAKE_MATCH_2}+sve>)
+      elseif(NOT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )-march=armv")
+        # No valid -march, so specify -march=armv8-a+sve as the default
+        target_compile_options(${target} PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RELEASE>>:-march=armv8-a+sve>)
+      endif()
+    else()
+      # TODO: support Windows
+    endif()
+    target_link_libraries(${target} PRIVATE faiss_sve)
+  endif()
+endfunction()

--- a/perf_tests/CMakeLists.txt
+++ b/perf_tests/CMakeLists.txt
@@ -27,55 +27,7 @@ add_library(faiss_perf_tests_utils
 target_include_directories(faiss_perf_tests_utils PRIVATE
    ${PROJECT_SOURCE_DIR}/../..)
 
-function(link_to_faiss_lib target)
-  if(NOT FAISS_OPT_LEVEL STREQUAL "avx2" AND NOT FAISS_OPT_LEVEL STREQUAL "avx512" AND NOT FAISS_OPT_LEVEL STREQUAL "sve")
-    target_link_libraries(${target} PRIVATE faiss)
-  endif()
-
-  if(FAISS_OPT_LEVEL STREQUAL "avx2")
-    if(NOT WIN32)
-      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma>)
-    else()
-      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX2>)
-    endif()
-    target_link_libraries(${target} PRIVATE faiss_avx2)
-  endif()
-
-  if(FAISS_OPT_LEVEL STREQUAL "avx512")
-    if(NOT WIN32)
-      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mavx512f -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw>)
-    else()
-      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX512>)
-    endif()
-    target_link_libraries(${target} PRIVATE faiss_avx512)
-  endif()
-
-  if(FAISS_OPT_LEVEL STREQUAL "sve")
-    if(NOT WIN32)
-      if("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )-march=native")
-        # Do nothing, expect SVE to be enabled by -march=native
-      elseif("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )(-march=armv[0-9]+(\\.[1-9]+)?-[^+ ](\\+[^+$ ]+)*)")
-        # Add +sve
-        target_compile_options(${target}  PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:${CMAKE_MATCH_2}+sve>)
-      elseif(NOT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )-march=armv")
-        # No valid -march, so specify -march=armv8-a+sve as the default
-        target_compile_options(${target} PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-march=armv8-a+sve>)
-      endif()
-      if("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )-march=native")
-        # Do nothing, expect SVE to be enabled by -march=native
-      elseif("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )(-march=armv[0-9]+(\\.[1-9]+)?-[^+ ](\\+[^+$ ]+)*)")
-        # Add +sve
-        target_compile_options(${target}  PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RELEASE>>:${CMAKE_MATCH_2}+sve>)
-      elseif(NOT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )-march=armv")
-        # No valid -march, so specify -march=armv8-a+sve as the default
-        target_compile_options(${target} PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RELEASE>>:-march=armv8-a+sve>)
-      endif()
-    else()
-      # TODO: support Windows
-    endif()
-    target_link_libraries(${target} PRIVATE faiss_sve)
-  endif()
-endfunction()
+include(../cmake/link_to_faiss_lib.cmake)
 
 link_to_faiss_lib(faiss_perf_tests_utils)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,53 +40,9 @@ set(FAISS_TEST_SRC
 
 add_executable(faiss_test ${FAISS_TEST_SRC})
 
-if(NOT FAISS_OPT_LEVEL STREQUAL "avx2" AND NOT FAISS_OPT_LEVEL STREQUAL "avx512" AND NOT FAISS_OPT_LEVEL STREQUAL "sve")
-  target_link_libraries(faiss_test PRIVATE faiss)
-endif()
+include(../cmake/link_to_faiss_lib.cmake)
 
-if(FAISS_OPT_LEVEL STREQUAL "avx2")
-  if(NOT WIN32)
-    target_compile_options(faiss_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma>)
-  else()
-    target_compile_options(faiss_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX2>)
-  endif()
-  target_link_libraries(faiss_test PRIVATE faiss_avx2)
-endif()
-
-if(FAISS_OPT_LEVEL STREQUAL "avx512")
-  if(NOT WIN32)
-    target_compile_options(faiss_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mavx512f -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw>)
-  else()
-    target_compile_options(faiss_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX512>)
-  endif()
-  target_link_libraries(faiss_test PRIVATE faiss_avx512)
-endif()
-
-if(FAISS_OPT_LEVEL STREQUAL "sve")
-  if(NOT WIN32)
-    if("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )-march=native")
-      # Do nothing, expect SVE to be enabled by -march=native
-    elseif("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )(-march=armv[0-9]+(\\.[1-9]+)?-[^+ ](\\+[^+$ ]+)*)")
-      # Add +sve
-      target_compile_options(faiss_test PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:${CMAKE_MATCH_2}+sve>)
-    elseif(NOT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} " MATCHES "(^| )-march=armv")
-      # No valid -march, so specify -march=armv8-a+sve as the default
-      target_compile_options(faiss_test PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-march=armv8-a+sve>)
-    endif()
-    if("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )-march=native")
-      # Do nothing, expect SVE to be enabled by -march=native
-    elseif("${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )(-march=armv[0-9]+(\\.[1-9]+)?-[^+ ](\\+[^+$ ]+)*)")
-      # Add +sve
-      target_compile_options(faiss_test PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RELEASE>>:${CMAKE_MATCH_2}+sve>)
-    elseif(NOT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} " MATCHES "(^| )-march=armv")
-      # No valid -march, so specify -march=armv8-a+sve as the default
-      target_compile_options(faiss_test PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RELEASE>>:-march=armv8-a+sve>)
-    endif()
-  else()
-    # TODO: support Windows
-  endif()
-  target_link_libraries(faiss_test PRIVATE faiss_sve)
-endif()
+link_to_faiss_lib(faiss_test)
 
 target_link_libraries(faiss_test PUBLIC faiss_example_external_module)
 


### PR DESCRIPTION
…e (#3939)

Summary:
Add `cmake/link_to_faiss_lib.cmake`, which exposes a useful and reusable CMake `link_to_faiss_lib()` function

Pull Request resolved: https://github.com/facebookresearch/faiss/pull/3939

Reviewed By: mnorris11

Differential Revision: D64250261

Pulled By: mengdilin

fbshipit-source-id: bab5b7fab8effb33cb73024eb7eefd2319998e5b